### PR TITLE
Remove usage of tooltip custom-target

### DIFF
--- a/components/attachment-opener-secure.js
+++ b/components/attachment-opener-secure.js
@@ -7,8 +7,7 @@ export class AttachmentOpenerSecure extends AttachmentOpener {
 	static get properties() {
 		return {
 			canOpen: { type: Boolean },
-			componentType: { type: String },
-			_showTooltip: { type: String },
+			componentType: { type: String }
 		};
 	}
 
@@ -16,52 +15,14 @@ export class AttachmentOpenerSecure extends AttachmentOpener {
 		return css`
 			:host {
 				display: block;
+				outline: none;
 			}
 		`;
 	}
 
 	constructor() {
 		super();
-		this._showTooltip = false;
-	}
-
-	get _showTooltip() {
-		return this.__showTooltip;
-	}
-
-	set _showTooltip(value) {
-		this.__showTooltip = value;
-		if (value) {
-			this._startCloseTooltipTimer(value);
-		}
-	}
-
-	_closeTooltip() {
-		this.showTooltip = false;
-		document.removeEventListener('click', this._closeTooltip);
-		this.shadowRoot.getElementById('tooltip').hide();
-		this._closeTooltipHandle = null;
-	}
-
-	_startCloseTooltipTimer(showTooltip) {
-		if (showTooltip) {
-			clearTimeout(this._closeTooltipHandle);
-			this._closeTooltipHandle = setTimeout(this._closeTooltip.bind(this), 7000);
-		}
-	}
-
-	_onResize() {
-		if (this.offsetParent && this._showTooltip) {
-			const parentRect = this.offsetParent.getBoundingClientRect();
-			this._setTooltipBoundary(parentRect);
-		}
-	}
-
-	_setTooltipBoundary(parentRect) {
-		this.shadowRoot.getElementById('tooltip').boundary = {
-			left: 0,
-			right: parentRect.width,
-		};
+		this.setAttribute('tabindex', '-1');
 	}
 
 	_viewAttachment(e) {
@@ -73,58 +34,13 @@ export class AttachmentOpenerSecure extends AttachmentOpener {
 			super._viewAttachment(e);
 			return;
 		}
-
-		this._showTooltip = !this._showTooltip;
-
-		const tooltip = this.shadowRoot.getElementById('tooltip');
-		if (this._showTooltip) {
-			tooltip.show();
-
-			const parent = e.currentTarget.getBoundingClientRect();
-
-			this._setTooltipBoundary(parent);
-
-			if (e.keyCode) {
-				tooltip.customTarget = {
-					top: 0,
-					left: parent.width / 2,
-					right: parent.width / 2,
-					height: 0,
-					width: 0,
-				};
-			} else {
-				tooltip.customTarget = {
-					top: e.clientY - parent.top,
-					left: e.clientX - parent.left,
-					right: parent.right - e.clientX,
-					height: 0,
-					width: 0,
-				};
-			}
-
-			setTimeout(() => document.addEventListener('click', this._closeTooltip.bind(this)), 0);
-		} else {
-			document.removeEventListener('click', this._closeTooltip);
-			tooltip.hide();
-		}
-		this.requestUpdate();
+		this.focus();
 		announce(this.localize(`attachment_cannot_open_${this.componentType}`));
-	}
-
-	connectedCallback() {
-		super.connectedCallback();
-		window.addEventListener('resize', this._onResize);
-	}
-	disconnectedCallback() {
-		window.removeEventListener('resize', this._onResize);
-		super.disconnectedCallback();
 	}
 
 	render() {
 		return html`
-			<d2l-tooltip id="tooltip" custom-target="" position="top"
-				>${this.localize(`attachment_cannot_open_${this.componentType}`)}</d2l-tooltip
-			>
+			${!this.canOpen ? html`<d2l-tooltip id="tooltip" position="top">${this.localize(`attachment_cannot_open_${this.componentType}`)}</d2l-tooltip>` : null}
 			<slot></slot>
 		`;
 	}

--- a/components/attachment-opener-secure.js
+++ b/components/attachment-opener-secure.js
@@ -20,9 +20,17 @@ export class AttachmentOpenerSecure extends AttachmentOpener {
 		`;
 	}
 
-	constructor() {
-		super();
-		this.setAttribute('tabindex', '-1');
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		changedProperties.forEach((_, prop) => {
+			if (prop === 'canOpen') {
+				if (this.canOpen) {
+					this.removeAttribute('tabindex');
+				} else {
+					this.setAttribute('tabindex', '0');
+				}
+			}
+		});
 	}
 
 	_viewAttachment(e) {
@@ -34,7 +42,6 @@ export class AttachmentOpenerSecure extends AttachmentOpener {
 			super._viewAttachment(e);
 			return;
 		}
-		this.focus();
 		announce(this.localize(`attachment_cannot_open_${this.componentType}`));
 	}
 


### PR DESCRIPTION
# Changes
- Remove tooltip `customTarget` so that it always opens above instead of where the user clicks.
- Remove tooltip boundary because tooltips are automatically bounded by the viewport / iframe boundary.
- Remove custom opening and closing logic so the tooltip can manage its own opening and closing for attachments that cannot be opened.

## Old (open at mouse click)
![attachment-tooltip-old](https://user-images.githubusercontent.com/11379933/78388008-4627e380-75ae-11ea-9f33-0743c1395779.gif)

## New (open above)
![attachment-tooltip](https://user-images.githubusercontent.com/11379933/78387644-af5b2700-75ad-11ea-8703-53cbc40a7839.gif)
