### PR TITLE
DE39243 - replace {orgUnitId} in href

### DIFF
--- a/mixins/attachment-mixin.js
+++ b/mixins/attachment-mixin.js
@@ -1,4 +1,6 @@
-export const AttachmentMixin = superclass => class extends superclass {
+import { RequestProviderMixin } from './request-provider-mixin.js';
+
+export const AttachmentMixin = superclass => class extends RequestProviderMixin(superclass) {
 	static get properties() {
 		return {
 			baseHref: { type: String },
@@ -13,9 +15,21 @@ export const AttachmentMixin = superclass => class extends superclass {
 	}
 
 	resolveHref(href) {
+		if (href) {
+			const orgUnitId = this.requestProvider('d2l-provider-org-unit-id');
+			href = orgUnitId ? this._replaceStrings(href, 'orgUnitId', orgUnitId) : href;
+		}
 		if (href && this.baseHref && href[0] === '/') {
 			return this.baseHref + href.substring(1);
 		}
 		return href;
+	}
+
+	_replaceStrings(str, replacementToken, replacementValue) {
+		if (!str) {
+			return str;
+		}
+		const regEx = new RegExp(`{${replacementToken}}`, 'i');
+		return str.replace(regEx, replacementValue);
 	}
 };


### PR DESCRIPTION
We replace {orgUnitId} that is present in QuickLink hrefs with the actual orgUnitId.
The orgUnitId is provided by activities.