### PR TITLE
Reset asyncState when unfurling

### DIFF
--- a/components/attachment.js
+++ b/components/attachment.js
@@ -127,6 +127,7 @@ export class Attachment extends RequestProviderMixin(AsyncContainerMixin(BaseMix
 
 	async _unfurl(attachment) {
 		try {
+			this.resetAsyncState();
 			this._unfurlResult = await this._callUnfurl(attachment);
 			if (!this._unfurlResult) {
 				this._unfurlResult = {


### PR DESCRIPTION
In cases where the attachment URL is updated the loading skeleton is not displayed while the new value is being unfurled. This change resets the asyncState so that this occurs.