### PR TITLE
reject annotation nodes from MathML

### DIFF
--- a/helpers/links-in-message-processor.js
+++ b/helpers/links-in-message-processor.js
@@ -17,7 +17,11 @@ export class LinksInMessageProcessor {
 	_getTreewalker(message) {
 		const domData = (new window.DOMParser()).parseFromString(message, 'text/html');
 		const treeWalker = domData.createTreeWalker(domData.body, NodeFilter.SHOW_ALL,  {
-			acceptNode: ({nodeType, nodeName, textContent, src}) => {
+			acceptNode: (node) => {
+				let {nodeType, nodeName, textContent, src} = node;
+				if(nodeName === 'annotation' && node.hasAttribute('encoding') && node.getAttribute('encoding') === 'wiris') {
+					return NodeFilter.FILTER_REJECT;
+				}
 				if (nodeType === Node.TEXT_NODE) {
 					return new RegExp(LinksRegExpString, 'ig').test(textContent) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP;
 				}

--- a/helpers/links-in-message-processor.js
+++ b/helpers/links-in-message-processor.js
@@ -18,8 +18,8 @@ export class LinksInMessageProcessor {
 		const domData = (new window.DOMParser()).parseFromString(message, 'text/html');
 		const treeWalker = domData.createTreeWalker(domData.body, NodeFilter.SHOW_ALL,  {
 			acceptNode: (node) => {
-				let {nodeType, nodeName, textContent, src} = node;
-				if(nodeName === 'annotation' && node.hasAttribute('encoding') && node.getAttribute('encoding') === 'wiris') {
+				const {nodeType, nodeName, textContent, src} = node;
+				if (nodeName === 'annotation' && node.hasAttribute('encoding') && node.getAttribute('encoding') === 'wiris') {
 					return NodeFilter.FILTER_REJECT;
 				}
 				if (nodeType === Node.TEXT_NODE) {


### PR DESCRIPTION
Fixes https://trello.com/c/Wc8qLErM/305-html-editor-automatically-adds-mathml-attachment-when-adding-mathml-equations

MathML adds an annotation node that looks like
```
<annotation encoding="wiris">
  {
    "version":"1.1",
    "math":"&lt;math xmlns=&quot;http://www.w3.org/1998/Math/MathML&quot;&gt;&lt;msqrt&gt;&lt;mn&gt;45&lt;/mn&gt;&lt;/msqrt&gt;&lt;/math&gt;"
  }
</annotation>
```
and the contained url is turned into an unwanted attachment. This fix looks specifically for this node and rejects it.